### PR TITLE
Fix permissions issue when running tests during checks.

### DIFF
--- a/app/recipe/tests/test_recipe_api.py
+++ b/app/recipe/tests/test_recipe_api.py
@@ -29,7 +29,7 @@ from rest_framework.test import APIClient
 
 
 RECIPES_URL = reverse('recipe:recipe-list')
-TESTS_FILE_DIR = 'test_data'
+TESTS_FILE_DIR = '/vol/web/test_data'
 
 
 def recipe_detail_url(recipe_id):


### PR DESCRIPTION
The current working directory; /app belongs to the root user; therefore the attempt by the non-root user to create the test_data folder in it will face permission issues. The test_data folder should be created in a folder owned by the non-root user; for example: /vol/web/